### PR TITLE
Fix User redeclaration

### DIFF
--- a/advanced/src/schema.graphql
+++ b/advanced/src/schema.graphql
@@ -24,5 +24,5 @@ type User {
   id: ID!
   email: String!
   name: String!
-  posts: [Post!]!
+  posts: [Post!]
 }


### PR DESCRIPTION
When the type is converted by prisma from the datamodel it becomes:
```graphql
type User implements Node {
  id: ID!
  email: String!
  password: String!
  name: String!
  posts(where: PostWhereInput, orderBy: PostOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Post!]
  role: Role!
}
```
When redeclaring User to remove the password field, the posts should lose that part from the datamodel.
I caught this using declaration types for the "app" part.
It follows issue #273 but here I'm telling the resolvers what to return, like so
```typescript
import { Mutation as MutationType } from "../../typings/types";

export const auth = {
  async signup(
    parent: never,
    args: SignupMutationArgs,
    ctx: Context,
    info: never
  ): Promise<MutationType["signup"]> {
    const password = await bcrypt.hash(args.password, 10);
    const user = await ctx.db.mutation.createUser({
      data: { ...args, password }
    });

    return {
      token: jwt.sign(
        { userId: user.id },
        invariant<string>("string", process.env.APP_SECRET)
      ),
      user
    };
  },
}
```
the compiled warned me that createUser returns user[] | undefined but the "app" part was supposed to return user[] as the user data.