### PR TITLE
fix: return correct result when passing name in the hello query

### DIFF
--- a/minimal/src/index.ts
+++ b/minimal/src/index.ts
@@ -9,7 +9,7 @@ const typeDefs = `
 const resolvers = {
   Query: {
     hello: (_, { name }) => {
-      const returnValue = !name ? `Hello ${name || 'World!'}` : null
+      const returnValue = `Hello ${name || 'World!'}`
       return returnValue
     }
   }


### PR DESCRIPTION
Small fix to make sure the name gets passed back by the `hello` query:

![image](https://user-images.githubusercontent.com/36491/46722738-e3b18980-cc3b-11e8-87ad-aa40dca30df1.png)
