### PR TITLE
Update basic README to drop the deprecated --boilerplate flag

### DIFF
--- a/basic/README.md
+++ b/basic/README.md
@@ -30,14 +30,16 @@ npm install -g graphql-cli
 
 ```sh
 # 1. Bootstrap GraphQL server in directory `my-app`, based on `typescript-basic` boilerplate
-graphql create my-app --boilerplate typescript-basic
+graphql create my-app
 
-# 2. When prompted, deploy the Prisma service to a _public cluster_
+# 2. Select `typescript-basic` from the list of boilerplate project names.
 
-# 3. Navigate to the new project
+# 3. When prompted, deploy the Prisma service to a _public cluster_
+
+# 4. Navigate to the new project
 cd my-app
 
-# 4. Start server (runs on http://localhost:4000) and open GraphQL Playground
+# 5. Start server (runs on http://localhost:4000) and open GraphQL Playground
 yarn dev
 ```
 


### PR DESCRIPTION
The `grapqhl` package had dropped the `--boilerplate` flag. Resulting in `Unknown argument: boilerplate` when you try to create the new project.

This PR updates the documentation to reflect that.